### PR TITLE
Add initial dialog migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # React + TypeScript + Vite
 
-Hello, world! This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.  
+Hello, world! This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Database migrations
+
+SQL files live in `supabase/migrations`. Apply them with the [Supabase CLI](https://supabase.com/docs/guides/cli):
+
+```bash
+supabase link --project-ref <project-id>
+supabase db push
+```

--- a/supabase/migrations/001_create_initial_dialogue_templates.sql
+++ b/supabase/migrations/001_create_initial_dialogue_templates.sql
@@ -1,0 +1,11 @@
+CREATE TYPE field_type AS ENUM ('text', 'text[]', 'tag[]', 'paragraph');
+
+CREATE TABLE IF NOT EXISTS public.initial_dialogue_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  field_name TEXT NOT NULL,
+  label TEXT NOT NULL,
+  field_type field_type NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT initial_dialogue_templates_field_name_key UNIQUE(field_name)
+);

--- a/supabase/migrations/002_create_user_initial_dialogue_responses.sql
+++ b/supabase/migrations/002_create_user_initial_dialogue_responses.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS public.user_initial_dialogue_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  template_id UUID NOT NULL REFERENCES public.initial_dialogue_templates(id) ON DELETE CASCADE,
+  response JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add `initial_dialogue_templates` and `user_initial_dialogue_responses` migration scripts
- document how to apply migrations

## Testing
- `npm run lint` *(fails: Unexpected any due to existing code)*

------
https://chatgpt.com/codex/tasks/task_e_688a19f2fa0c832e8e395061602cdd28