### PR TITLE
Add profile preferences page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 import Index from "./pages/Index";
+import Preferences from "./pages/profile/preferences";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/profile/preferences" element={<Preferences />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -55,7 +56,10 @@ export const Dashboard: React.FC = () => {
                 )}
               </div>
               
-              <div className="flex items-center gap-2 text-sm text-gray-600">
+              <div className="flex items-center gap-3 text-sm text-gray-600">
+                <Link to="/profile/preferences" className="underline">
+                  Preferences
+                </Link>
                 <span>{user.email}</span>
                 <Button variant="ghost" size="sm" onClick={logout}>
                   <LogOut className="h-4 w-4" />

--- a/src/components/PromptPreview.tsx
+++ b/src/components/PromptPreview.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface PromptPreviewProps {
+  responses: Record<string, any>;
+}
+
+const PromptPreview: React.FC<PromptPreviewProps> = ({ responses }) => {
+  return (
+    <div className="max-w-2xl mx-auto p-4 border rounded-md bg-white/50">
+      <pre className="whitespace-pre-wrap text-sm">
+        {JSON.stringify(responses, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+export default PromptPreview;

--- a/src/pages/profile/preferences.tsx
+++ b/src/pages/profile/preferences.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { AppProvider, useAppContext } from '@/contexts/AppContext';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import PromptPreview from '@/components/PromptPreview';
+
+const PreferencesInner: React.FC = () => {
+  const { user } = useAppContext();
+  const [responses, setResponses] = useState<any>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadResponses = async () => {
+      if (!user) return;
+      const { data } = await supabase
+        .from('user_initial_dialogue_responses')
+        .select('*')
+        .eq('user_id', user.id)
+        .single();
+      if (data) {
+        setResponses(data);
+      }
+      setLoading(false);
+    };
+    loadResponses();
+  }, [user]);
+
+  const saveField = async (key: string, value: string) => {
+    setResponses((prev: any) => ({ ...prev, [key]: value }));
+    if (!user) return;
+    await supabase
+      .from('user_initial_dialogue_responses')
+      .update({ [key]: value })
+      .eq('user_id', user.id);
+  };
+
+  if (!user) return null;
+  if (loading) return <div className="p-4">Loading...</div>;
+
+  const fields = Object.entries(responses).filter(
+    ([k]) => !['id', 'user_id', 'created_at'].includes(k)
+  );
+
+  return (
+    <div className="p-4 space-y-6">
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>User Preferences</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {fields.map(([key, value]) => (
+            <div key={key} className="space-y-2">
+              <label className="block text-sm font-medium capitalize">
+                {key.replace(/_/g, ' ')}
+              </label>
+              {String(value ?? '').length > 60 ? (
+                <Textarea
+                  value={value ?? ''}
+                  onChange={(e) => saveField(key, e.target.value)}
+                  onBlur={(e) => saveField(key, e.target.value)}
+                  className="min-h-[80px]"
+                />
+              ) : (
+                <Input
+                  value={value ?? ''}
+                  onChange={(e) => saveField(key, e.target.value)}
+                  onBlur={(e) => saveField(key, e.target.value)}
+                />
+              )}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <PromptPreview responses={responses} />
+    </div>
+  );
+};
+
+const PreferencesPage: React.FC = () => (
+  <AppProvider>
+    <PreferencesInner />
+  </AppProvider>
+);
+
+export default PreferencesPage;


### PR DESCRIPTION
## Summary
- show new user preferences page at `/profile/preferences`
- add `PromptPreview` placeholder component
- link to preferences from the dashboard
- wire new page into router

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a1a5c6efc832ea0c189a9dbd3e872