### PR TITLE
Implement prompt builder and preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 import Index from "./pages/Index";
+import Preferences from "./pages/Preferences";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/preferences" element={<Preferences />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/PromptPreview.tsx
+++ b/src/components/PromptPreview.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface PromptPreviewProps {
+  prompt: string;
+}
+
+export const PromptPreview: React.FC<PromptPreviewProps> = ({ prompt }) => {
+  if (!prompt) return null;
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>Prompt Preview</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <pre className="whitespace-pre-wrap text-sm font-mono">{prompt}</pre>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/lib/supabase/promptBuilder.ts
+++ b/src/lib/supabase/promptBuilder.ts
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabase';
+
+export interface DialogueResponse {
+  question: string;
+  response: string;
+}
+
+/**
+ * Generate a descriptive song prompt based on a user's initial dialogue responses.
+ * Fetches all responses from `user_initial_dialogue_responses` for the given user
+ * and assembles them into a single prompt string.
+ */
+export async function generateSongPrompt(userId: string): Promise<string> {
+  const { data, error } = await supabase
+    .from('user_initial_dialogue_responses')
+    .select('question, response')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Failed to fetch dialogue responses:', error);
+    throw error;
+  }
+
+  if (!data || data.length === 0) {
+    return '';
+  }
+
+  // Assemble the prompt using the collected responses.
+  const lines = data.map((entry) => `${entry.question.trim()}: ${entry.response.trim()}`);
+
+  return `Use the following user preferences to craft a personalised song.\n${lines.join('\n')}`;
+}

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { useAppContext } from '@/contexts/AppContext';
+import { generateSongPrompt } from '@/lib/supabase/promptBuilder';
+import { PromptPreview } from '@/components/PromptPreview';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+const Preferences: React.FC = () => {
+  const { user } = useAppContext();
+  const [prompt, setPrompt] = useState('');
+
+  useEffect(() => {
+    const fetchPrompt = async () => {
+      if (user?.id) {
+        try {
+          const p = await generateSongPrompt(user.id);
+          setPrompt(p);
+        } catch (error) {
+          console.error('Failed to build prompt', error);
+        }
+      }
+    };
+    fetchPrompt();
+  }, [user]);
+
+  return (
+    <div className="space-y-6">
+      <Card className="w-full max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>Preferences</CardTitle>
+          <CardDescription>Your initial dialogue responses</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-600">
+            These preferences are used to generate a personalised song prompt.
+          </p>
+        </CardContent>
+      </Card>
+      <PromptPreview prompt={prompt} />
+    </div>
+  );
+};
+
+export default Preferences;


### PR DESCRIPTION
## Summary
- create prompt builder to fetch user dialogue responses
- add prompt preview card
- add preferences page that shows prompt
- expose route `/preferences`

## Testing
- `npm run lint` *(fails: 16 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a1a6a01fc832eb7af9b2c1842745e