### PR TITLE
Add is_active and order fields with policy update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ SQL files live in `supabase/migrations`. Apply them with the [Supabase CLI](http
 ```bash
 supabase link --project-ref <project-id>
 supabase db push
+```
+
+The migration `003_update_initial_dialogue_templates.sql` adds `is_active`,
+`language`, and `order` columns to the `initial_dialogue_templates` table and
+populates existing rows with an ordering based on creation time.

--- a/supabase/migrations/003_update_initial_dialogue_templates.sql
+++ b/supabase/migrations/003_update_initial_dialogue_templates.sql
@@ -1,0 +1,8 @@
+ALTER TABLE initial_dialogue_templates
+  ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS language TEXT NOT NULL DEFAULT 'en',
+  ADD COLUMN IF NOT EXISTS "order" INT NOT NULL DEFAULT 0;
+
+UPDATE initial_dialogue_templates
+  SET "order" = row_number() OVER (ORDER BY created_at)
+  WHERE "order" = 0;

--- a/supabase/policies/initial_dialogue_templates.sql
+++ b/supabase/policies/initial_dialogue_templates.sql
@@ -6,3 +6,8 @@ CREATE POLICY "Admins can modify dialogue templates"
   FOR ALL
   USING ((auth.jwt() ->> 'role') = 'admin')
   WITH CHECK ((auth.jwt() ->> 'role') = 'admin');
+
+CREATE POLICY "Authenticated users read active templates"
+  ON initial_dialogue_templates
+  FOR SELECT
+  USING (auth.uid() IS NOT NULL AND is_active);


### PR DESCRIPTION
## Summary
- add `is_active`, `language`, and `order` fields to `initial_dialogue_templates`
- create policy for authenticated users to read active templates
- document new migration in README

## Testing
- `npm install`
- `npm run lint` *(fails: unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a36e1cf0c832ebfb5ef6036da7bb5