### PR TITLE
Add helper to transform dialogue answers

### DIFF
--- a/src/lib/transformDialogue.ts
+++ b/src/lib/transformDialogue.ts
@@ -1,0 +1,12 @@
+export interface Template {
+  field_name: string;
+}
+
+export function buildSemanticData(
+  templates: Template[],
+  answers: Record<string, unknown>
+) {
+  const result: Record<string, unknown> = {};
+  for (const t of templates) result[t.field_name] = answers[t.field_name];
+  return result;
+}


### PR DESCRIPTION
## Summary
- add `buildSemanticData` helper
- compute prompt JSON data in `DialogueWizard`
- show how the data will feed prompt builder for personalised lyrics

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688a3dfc0710832eaa0357803f73d175