### PR TITLE
Update prompt builder to include question labels

### DIFF
--- a/src/lib/supabase/promptBuilder.ts
+++ b/src/lib/supabase/promptBuilder.ts
@@ -1,7 +1,9 @@
 import { supabase } from '@/lib/supabase';
 
 export interface DialogueResponse {
-  question: string;
+  initial_dialogue_templates: {
+    label: string;
+  };
   response: string;
 }
 
@@ -13,7 +15,7 @@ export interface DialogueResponse {
 export async function generateSongPrompt(userId: string): Promise<string> {
   const { data, error } = await supabase
     .from('user_initial_dialogue_responses')
-    .select('question, response')
+    .select('initial_dialogue_templates.label, response')
     .eq('user_id', userId)
     .order('created_at', { ascending: true });
 
@@ -27,7 +29,9 @@ export async function generateSongPrompt(userId: string): Promise<string> {
   }
 
   // Assemble the prompt using the collected responses.
-  const lines = data.map((entry) => `${entry.question.trim()}: ${entry.response.trim()}`);
+  const lines = data.map(
+    (entry) => `${entry.initial_dialogue_templates.label.trim()}: ${String(entry.response).trim()}`,
+  );
 
   return `Use the following user preferences to craft a personalised song.\n${lines.join('\n')}`;
 }


### PR DESCRIPTION
## Summary
- join initial dialogue responses with template labels
- build prompts using joined label field

## Testing
- `npm run lint` *(fails: no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a3fbdfbb4832e94cbb4bcae9e48a4