### PR TITLE
Fix missing context on initial dialogue

### DIFF
--- a/src/pages/initial-dialogue.tsx
+++ b/src/pages/initial-dialogue.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import DialogueWizard from '@/components/InitialDialogue/DialogueWizard';
+import { AppProvider } from '@/contexts/AppContext';
 
-const InitialDialoguePage: React.FC = () => <DialogueWizard />;
+const InitialDialoguePage: React.FC = () => (
+  <AppProvider>
+    <DialogueWizard />
+  </AppProvider>
+);
 
 export default InitialDialoguePage;


### PR DESCRIPTION
## Summary
- wrap `DialogueWizard` with `AppProvider`
- verify build and lint succeed

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` then `curl http://localhost:8080/initial-dialogue | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688a4e9422c8832e8ad0b71773c32df2