### PR TITLE
Use env vars for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-key

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ supabase db push
 The migration `003_update_initial_dialogue_templates.sql` adds `is_active`,
 `language`, and `order` columns to the `initial_dialogue_templates` table and
 populates existing rows with an ordering based on creation time.
+
+## Environment Variables
+
+Create a `.env` file in the project root (you can copy `.env.example`) and
+provide your Supabase credentials:
+
+```bash
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_KEY=<your-supabase-key>
+```
+
+These variables are required for both local development and deployment.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Initialize Supabase client with correct credentials
-const supabaseUrl = 'https://abhhiplxeaawdnxnjovf.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFiaGhpcGx4ZWFhd2RueG5qb3ZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM0NTg4MDEsImV4cCI6MjA2OTAzNDgwMX0.QcAMwj1cLYXOppRR71Vbzq2J4ao6YtngNUpXkbWNGtE';
+// Initialize Supabase client using environment variables
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseKey = process.env.SUPABASE_KEY as string;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "functions": {
+    "api/suno-webhook.ts": {
+      "runtime": "nodejs18.x"
+    },
+    "api/webhook-data.ts": {
+      "runtime": "nodejs18.x"
+    },
+    "api/proxy-audio.ts": {
+      "runtime": "nodejs18.x"
+    }
+  },
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ],
+  "env": {
+    "SUPABASE_URL": "@supabase-url",
+    "SUPABASE_KEY": "@supabase-key"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Supabase client using `process.env`
- document required environment variables
- provide `.env.example`
- configure Vercel with env vars

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a5cb3a67c832eb53bdeb856dc58bc