### PR TITLE
Update Supabase env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for local development
+# Replace with your project's credentials
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env.local
+dist/

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ supabase db push
 The migration `003_update_initial_dialogue_templates.sql` adds `is_active`,
 `language`, and `order` columns to the `initial_dialogue_templates` table and
 populates existing rows with an ordering based on creation time.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in your Supabase credentials using the `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` variables.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Initialize Supabase client with correct credentials
-const supabaseUrl = 'https://abhhiplxeaawdnxnjovf.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFiaGhpcGx4ZWFhd2RueG5qb3ZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM0NTg4MDEsImV4cCI6MjA2OTAzNDgwMX0.QcAMwj1cLYXOppRR71Vbzq2J4ao6YtngNUpXkbWNGtE';
+// Initialize Supabase client using environment variables
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/vercel.json
+++ b/vercel.json
@@ -19,5 +19,9 @@
       "src": "/(.*)",
       "dest": "/index.html"
     }
-  ]
+  ],
+  "env": {
+    "VITE_SUPABASE_URL": "@supabase-url",
+    "VITE_SUPABASE_ANON_KEY": "@supabase-anon-key"
+  }
 }


### PR DESCRIPTION
## Summary
- load Supabase creds from Vite env variables
- document new environment variables
- provide `.env.example`
- configure Vercel deployment to use the `VITE_` names
- ignore build output

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a68096278832ea260b1e928591bd5