### PR TITLE
Add initial dialogue options policy

### DIFF
--- a/supabase/policies/initial_dialogue_options.sql
+++ b/supabase/policies/initial_dialogue_options.sql
@@ -1,0 +1,21 @@
+-- Enable RLS and allow only admins to modify options
+ALTER TABLE initial_dialogue_options ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can modify dialogue options"
+  ON initial_dialogue_options
+  FOR ALL
+  USING ((auth.jwt() ->> 'role') = 'admin')
+  WITH CHECK ((auth.jwt() ->> 'role') = 'admin');
+
+CREATE POLICY "Authenticated users read options"
+  ON initial_dialogue_options
+  FOR SELECT
+  USING (
+    auth.uid() IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM initial_dialogue_templates t
+      WHERE t.id = template_id
+        AND t.is_active
+    )
+  );


### PR DESCRIPTION
## Summary
- add new policy for `initial_dialogue_options`
- enable RLS and allow admin changes
- allow authenticated users to read options for active templates

## Testing
- `npm ci --ignore-scripts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a9de535c4832eac5e3b151b685fd0