### PR TITLE
Use text input for mood

### DIFF
--- a/src/components/InitialDialogue/DialogueWizard.tsx
+++ b/src/components/InitialDialogue/DialogueWizard.tsx
@@ -62,7 +62,11 @@ const DialogueWizard: React.FC<DialogueWizardProps> = ({ templates: initialTempl
 
       const templatesData = data || [];
       const optionTemplateIds = templatesData
-        .filter((t) => t.field_type === 'select' || t.field_type === 'slider')
+        .filter(
+          (t) =>
+            (t.field_type === 'select' || t.field_type === 'slider') &&
+            t.field_name !== 'mood'
+        )
         .map((t) => t.id);
 
       const optionsMap: Record<string | number, Option[]> = {};
@@ -196,7 +200,8 @@ const DialogueWizard: React.FC<DialogueWizardProps> = ({ templates: initialTempl
   }
 
   const template = templates[current];
-  const fieldType = template.field_type || 'text';
+  const fieldType =
+    template.field_name === 'mood' ? 'text' : template.field_type || 'text';
   const value =
     answers[template.field_name] ??
     (fieldType === 'multiselect' ? [] : fieldType === 'slider' ? undefined : '');

--- a/supabase/migrations/005_change_mood_field_type.sql
+++ b/supabase/migrations/005_change_mood_field_type.sql
@@ -1,0 +1,4 @@
+UPDATE initial_dialogue_templates
+SET field_type = 'text'
+WHERE field_name = 'mood';
+DELETE FROM initial_dialogue_options WHERE template_id IN (SELECT id FROM initial_dialogue_templates WHERE field_name = 'mood');


### PR DESCRIPTION
## Summary
- adjust option loading to ignore mood selections
- force `mood` template to render as a text input
- add migration to switch mood template type to text and drop options

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c8bcc2b68832e8f8adfb1d0065ba2