### PR TITLE
Add user dialogue response table

### DIFF
--- a/supabase/migrations/006_create_user_initial_dialogue_responses.sql
+++ b/supabase/migrations/006_create_user_initial_dialogue_responses.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS public.user_initial_dialogue_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id),
+  template_id UUID NOT NULL REFERENCES public.initial_dialogue_templates(id),
+  response TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_initial_dialogue_responses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow anyone to insert" ON user_initial_dialogue_responses
+  FOR INSERT
+  WITH CHECK (true);
+

--- a/supabase/policies/user_initial_dialogue_responses.sql
+++ b/supabase/policies/user_initial_dialogue_responses.sql
@@ -1,13 +1,7 @@
--- Enable RLS and allow users to insert or update only their own rows
+-- Enable RLS and allow anyone to insert responses
 ALTER TABLE user_initial_dialogue_responses ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Users can insert their own responses"
+CREATE POLICY "Anyone can insert responses" 
   ON user_initial_dialogue_responses
   FOR INSERT
-  WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own responses"
-  ON user_initial_dialogue_responses
-  FOR UPDATE
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- create table `user_initial_dialogue_responses`
- enable RLS and allow inserts from anyone

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ca66000e0832e8397331478cdd87f