### PR TITLE
Initialize PAS architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Supabase Edge Functions and backend environment variables
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUNO_API_KEY=your-suno-key
+LLM_MODE=local
+LLM_ENDPOINT=http://localhost:11434
+LLM_MODEL=mistral
+# If using OpenAI
+# OPENAI_API_KEY=your-openai-key
+# OPENAI_MODEL=gpt-4

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Vite frontend environment variables
+VITE_SUPABASE_URL=https://<your-project>.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUNO_API_KEY=your-suno-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env.local
+.env

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SongCraft AI</title>
+    <meta name="description" content="Generate personalized motivational songs using AI for mood enhancement and focus." />
+    <link rel="icon" type="image/svg+xml" href="/placeholder.svg" />
+
+    <meta property="og:title" content="SongCraft AI" />
+    <meta property="og:description" content="Generate personalized motivational songs using AI for mood enhancement and focus." />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/og.jpg" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="/og.jpg" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/scripts/seed_initial_dialogue.ts
+++ b/scripts/seed_initial_dialogue.ts
@@ -1,0 +1,2 @@
+// Seed script for initial dialogue templates
+// TODO: Populate Supabase with initial interview questions

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AudioPlayer() {
+  return <div>Audio Player Placeholder</div>;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/pages/InitialDialoguePage.tsx
+++ b/src/pages/InitialDialoguePage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function InitialDialoguePage() {
+  return <div>Initial Dialogue Page Placeholder</div>;
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return <div>Login Page Placeholder</div>;
+}

--- a/src/pages/SongDashboard.tsx
+++ b/src/pages/SongDashboard.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function SongDashboard() {
+  return <div>Song Dashboard Placeholder</div>;
+}

--- a/src/pages/SongDialoguePage.tsx
+++ b/src/pages/SongDialoguePage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function SongDialoguePage() {
+  return <div>Song Dialogue Page Placeholder</div>;
+}

--- a/supabase/functions/ai_router.ts
+++ b/supabase/functions/ai_router.ts
@@ -1,0 +1,6 @@
+// Edge function to route AI requests.
+// TODO: Implement LLM logic based on LLM_MODE env variable.
+
+export default async function handler(req: Request): Promise<Response> {
+  return new Response('AI Router Placeholder');
+}

--- a/supabase/functions/suno_webhook.ts
+++ b/supabase/functions/suno_webhook.ts
@@ -1,0 +1,5 @@
+// Edge function to receive Suno webhook events with audio URLs.
+
+export default async function handler(req: Request): Promise<Response> {
+  return new Response('Suno Webhook Placeholder');
+}


### PR DESCRIPTION
## Summary
- scaffold clean architecture per architecture.md
- add placeholder frontend pages and components
- add supabase edge function placeholders
- add seed script and environment file templates
- copy index.html into `public/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cf092f93c832e958b7cc6d8b6a406