### PR TITLE
Add Supabase tables and policies

### DIFF
--- a/supabase/migrations/007_create_song_dialogues.sql
+++ b/supabase/migrations/007_create_song_dialogues.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS public.song_dialogues (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  input JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/supabase/migrations/008_create_songs.sql
+++ b/supabase/migrations/008_create_songs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS public.songs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title TEXT,
+  lyrics TEXT,
+  prompt TEXT,
+  audio_url_1 TEXT,
+  audio_url_2 TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/supabase/migrations/009_create_profiles.sql
+++ b/supabase/migrations/009_create_profiles.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  full_name TEXT,
+  subscription_tier TEXT,
+  billing_status TEXT,
+  payment_provider_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/supabase/migrations/010_add_responses_json_to_user_initial_dialogue_responses.sql
+++ b/supabase/migrations/010_add_responses_json_to_user_initial_dialogue_responses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.user_initial_dialogue_responses
+  ADD COLUMN IF NOT EXISTS responses JSONB;

--- a/supabase/policies/profiles.sql
+++ b/supabase/policies/profiles.sql
@@ -1,0 +1,7 @@
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own profile"
+  ON profiles
+  FOR ALL
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);

--- a/supabase/policies/song_dialogues.sql
+++ b/supabase/policies/song_dialogues.sql
@@ -1,0 +1,7 @@
+ALTER TABLE song_dialogues ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own song_dialogues"
+  ON song_dialogues
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/supabase/policies/songs.sql
+++ b/supabase/policies/songs.sql
@@ -1,0 +1,7 @@
+ALTER TABLE songs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own songs"
+  ON songs
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/supabase/policies/user_initial_dialogue_responses.sql
+++ b/supabase/policies/user_initial_dialogue_responses.sql
@@ -1,7 +1,7 @@
--- Enable RLS and allow anyone to insert responses
 ALTER TABLE user_initial_dialogue_responses ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Anyone can insert responses" 
+CREATE POLICY "Users can manage own initial responses"
   ON user_initial_dialogue_responses
-  FOR INSERT
-  WITH CHECK (true);
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create migrations for song_dialogues, songs, and profiles
- extend user_initial_dialogue_responses with `responses` JSONB column
- add row-level security policies for new tables
- tighten policy for user_initial_dialogue_responses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d0d1dcd3c832eab6f264542587ae5