### PR TITLE
refactor: use env-based supabase client

### DIFF
--- a/src/components/InitialDialogue/DialogueWizard.tsx
+++ b/src/components/InitialDialogue/DialogueWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { buildSemanticData } from '@/lib/transformDialogue';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';

--- a/src/components/InitialDialogueForm.tsx
+++ b/src/components/InitialDialogueForm.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 
 const InitialDialogueForm: React.FC = () => {

--- a/src/components/SongHistory.tsx
+++ b/src/components/SongHistory.tsx
@@ -5,7 +5,7 @@ import { Music } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
 import { audioStorage, StoredAudio } from '@/services/audioStorage';
 import { sunoApi } from '@/services/sunoApi';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { Song } from '@/types/song';
 import { SongFilterSortControls } from './SongFilterSortControls';
 import { SongHistoryContent } from './SongHistoryContent';

--- a/src/components/TaskMappingViewer.tsx
+++ b/src/components/TaskMappingViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';

--- a/src/components/WebhookIntegrationTester.tsx
+++ b/src/components/WebhookIntegrationTester.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { downloadAndStore } from '@/services/audioStorage';
 import { CheckCircle, XCircle, Clock, Play } from 'lucide-react';
 
@@ -53,7 +53,7 @@ export const WebhookIntegrationTester: React.FC = () => {
     // Step 1: Test webhook POST
     updateResult('webhook', 'pending', 'Testing webhook POST request...');
     try {
-      const response = await fetch('https://abhhiplxeaawdnxnjovf.supabase.co/functions/v1/suno-webhook', {
+      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/suno-webhook`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(testPayload)

--- a/src/components/WebhookPayloadViewer.tsx
+++ b/src/components/WebhookPayloadViewer.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { RefreshCw, Eye, EyeOff } from 'lucide-react';
 
 interface WebhookLog {

--- a/src/components/WebhookStatusChecker.tsx
+++ b/src/components/WebhookStatusChecker.tsx
@@ -18,7 +18,7 @@ export const WebhookStatusChecker: React.FC = () => {
   const [checkResult, setCheckResult] = useState<WebhookCheckResult | null>(null);
   const [isChecking, setIsChecking] = useState(false);
 
-  const webhookUrl = 'https://abhhiplxeaawdnxnjovf.supabase.co/functions/v1/suno-webhook';
+  const webhookUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/suno-webhook`;
 
   const checkWebhookStatus = async () => {
     setIsChecking(true);

--- a/src/components/WebhookTester.tsx
+++ b/src/components/WebhookTester.tsx
@@ -35,7 +35,7 @@ export const WebhookTester: React.FC = () => {
   }, null, 2));
   
   // Use the correct function URL with function name
-  const [webhookUrl, setWebhookUrl] = useState('https://abhhiplxeaawdnxnjovf.supabase.co/functions/v1/suno-webhook');
+    const [webhookUrl, setWebhookUrl] = useState(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/suno-webhook`);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -128,7 +128,7 @@ export const WebhookTester: React.FC = () => {
               id="webhook-url"
               value={webhookUrl}
               onChange={(e) => setWebhookUrl(e.target.value)}
-              placeholder="https://abhhiplxeaawdnxnjovf.supabase.co/functions/v1/suno-webhook"
+                placeholder={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/suno-webhook`}
             />
             <p className="text-sm text-gray-600 mt-1">Use this URL in your SunoAPI callBackUrl parameter</p>
           </div>

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 
 interface User {

--- a/src/hooks/useWebhookPolling.tsx
+++ b/src/hooks/useWebhookPolling.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
 import { audioStorage } from '@/services/audioStorage';
 import { useToast } from '@/hooks/use-toast';

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-// Initialize Supabase client with correct credentials
-const supabaseUrl = 'https://abhhiplxeaawdnxnjovf.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFiaGhpcGx4ZWFhd2RueG5qb3ZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM0NTg4MDEsImV4cCI6MjA2OTAzNDgwMX0.QcAMwj1cLYXOppRR71Vbzq2J4ao6YtngNUpXkbWNGtE';
-
-export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/lib/supabase/promptBuilder.ts
+++ b/src/lib/supabase/promptBuilder.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 
 export interface DialogueResponse {
   initial_dialogue_templates: {

--- a/src/pages/InitialDialoguePage.tsx
+++ b/src/pages/InitialDialoguePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { AppProvider, useAppContext } from '@/contexts/AppContext';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 

--- a/src/services/sunoApi.ts
+++ b/src/services/sunoApi.ts
@@ -1,5 +1,5 @@
 import { audioStorage } from './audioStorage';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { v4 as uuidv4 } from 'uuid';
 
 interface SunoGenerateRequest {
@@ -38,7 +38,7 @@ class SunoApiService {
 
   private getCallbackUrl(): string {
     // Production Supabase webhook endpoint
-    return 'https://abhhiplxeaawdnxnjovf.supabase.co/functions/v1/suno-webhook';
+    return `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/suno-webhook`;
   }
 
   private async makeRequest(endpoint: string, options: RequestInit = {}) {


### PR DESCRIPTION
## Summary
- remove obsolete `supabase.ts` with hard-coded credentials
- switch all modules to `supabaseClient` and environment variables
- build Supabase function URLs from `VITE_SUPABASE_URL`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891c3dc998c832e9c76e6bc4314f385