### PR TITLE
feat: add completed songs dashboard

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
 
-export default function AudioPlayer() {
-  return <div>Audio Player Placeholder</div>;
+interface AudioPlayerProps {
+  src: string;
+}
+
+/**
+ * Simple wrapper around the native audio element. Accepts an audio source URL
+ * and renders controls for playback.
+ */
+export default function AudioPlayer({ src }: AudioPlayerProps) {
+  return (
+    <audio controls className="w-full" src={src}>
+      Your browser does not support the audio element.
+    </audio>
+  );
 }

--- a/src/components/SongFilterSortControls.tsx
+++ b/src/components/SongFilterSortControls.tsx
@@ -14,6 +14,8 @@ interface FilterSortControlsProps {
   setMoodFilter: (mood: string) => void;
   styleFilter: string;
   setStyleFilter: (style: string) => void;
+  searchQuery?: string;
+  setSearchQuery?: (query: string) => void;
 }
 
 export const SongFilterSortControls: React.FC<FilterSortControlsProps> = ({
@@ -23,13 +25,28 @@ export const SongFilterSortControls: React.FC<FilterSortControlsProps> = ({
   moodFilter,
   setMoodFilter,
   styleFilter,
-  setStyleFilter
+  setStyleFilter,
+  searchQuery = '',
+  setSearchQuery
 }) => {
   const uniqueMoods = Array.from(new Set(songs.map(s => s.mood).filter(Boolean)));
   const uniqueStyles = Array.from(new Set(songs.map(s => s.style).filter(Boolean)));
 
   return (
     <div className="flex flex-wrap gap-4 mb-6 p-4 bg-gray-50 rounded-lg">
+      {setSearchQuery && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium">Search:</label>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-40 px-2 py-1 border border-input rounded-md"
+            placeholder="Title"
+          />
+        </div>
+      )}
+
       <div className="flex items-center gap-2">
         <label className="text-sm font-medium">Sort by:</label>
         <Select value={sortBy} onValueChange={(value: SortOption) => setSortBy(value)}>

--- a/src/pages/SongDashboard.tsx
+++ b/src/pages/SongDashboard.tsx
@@ -1,5 +1,97 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import AudioPlayer from '@/components/AudioPlayer';
+import { supabase } from '@/lib/supabaseClient';
+import { Song } from '@/types/song';
+import { SongFilterSortControls } from '@/components/SongFilterSortControls';
+
+type SortOption = 'created_at_desc' | 'created_at_asc' | 'mood' | 'style';
 
 export default function SongDashboard() {
-  return <div>Song Dashboard Placeholder</div>;
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [sortBy, setSortBy] = useState<SortOption>('created_at_desc');
+  const [moodFilter, setMoodFilter] = useState('');
+  const [styleFilter, setStyleFilter] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    const fetchSongs = async () => {
+      const { data, error } = await supabase
+        .from('songs')
+        .select('*')
+        .eq('status', 'complete')
+        .order('created_at', { ascending: false });
+
+      if (!error && data) {
+        setSongs(data);
+      }
+    };
+
+    fetchSongs();
+  }, []);
+
+  const filteredSongs = songs.filter((song) => {
+    if (moodFilter && song.mood !== moodFilter) return false;
+    if (styleFilter && song.style !== styleFilter) return false;
+    if (
+      searchQuery &&
+      !(song.title || '').toLowerCase().includes(searchQuery.toLowerCase())
+    )
+      return false;
+    return true;
+  });
+
+  const sortedSongs = [...filteredSongs].sort((a, b) => {
+    switch (sortBy) {
+      case 'created_at_desc':
+        return (
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+      case 'created_at_asc':
+        return (
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        );
+      case 'mood':
+        return (a.mood || '').localeCompare(b.mood || '');
+      case 'style':
+        return (a.style || '').localeCompare(b.style || '');
+      default:
+        return 0;
+    }
+  });
+
+  return (
+    <div className="p-4 space-y-4">
+      <SongFilterSortControls
+        songs={songs}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        moodFilter={moodFilter}
+        setMoodFilter={setMoodFilter}
+        styleFilter={styleFilter}
+        setStyleFilter={setStyleFilter}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+      />
+
+      {sortedSongs.map((song) => (
+        <Card key={song.id}>
+          <CardHeader>
+            <CardTitle>{song.title || 'Untitled'}</CardTitle>
+            <CardDescription>
+              {new Date(song.created_at).toLocaleString()}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {song.audio_url && <AudioPlayer src={song.audio_url} />}
+          </CardContent>
+        </Card>
+      ))}
+
+      {sortedSongs.length === 0 && (
+        <p className="text-sm text-muted-foreground">No songs found.</p>
+      )}
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- list completed songs with title, date and audio player
- enable search and sorting via filter controls
- implement simple audio player component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891cda23804832ea7f7c06a03a9fb31