### PR TITLE
Rebuild initial dialogue templates schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ supabase db push
 ```
 
 The migration `003_update_initial_dialogue_templates.sql` adds `is_active`,
-`language`, and `order` columns to the `initial_dialogue_templates` table and
-populates existing rows with an ordering based on creation time.
+`language`, and `order` columns to the legacy `initial_dialogue_templates` table.
+Migration `011_recreate_initial_dialogue_templates.sql` replaces that table with a
+prompt-focused schema (`id`, `order`, `type`, `prompt_text`, `active`,
+`created_at`, `updated_at`) and seeds several sample prompts.

--- a/supabase/migrations/011_recreate_initial_dialogue_templates.sql
+++ b/supabase/migrations/011_recreate_initial_dialogue_templates.sql
@@ -1,0 +1,20 @@
+ALTER TABLE IF EXISTS initial_dialogue_templates RENAME TO initial_dialogue_templates_old;
+
+CREATE TABLE IF NOT EXISTS public.initial_dialogue_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "order" INT NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  prompt_text TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.initial_dialogue_templates ("order", type, prompt_text, active) VALUES
+  (1, 'emotion', 'Which song always lifts your spirits when you feel down?', TRUE),
+  (2, 'metaphor', 'If your mood today were a musical instrument, what would it be?', TRUE),
+  (3, 'valence', 'Describe a melody that captures how you feel right now.', TRUE),
+  (4, 'rhythm', 'What rhythm mirrors the pace of your day?', TRUE),
+  (5, 'memory', 'Share a lyric that has stuck with you recently.', TRUE),
+  (6, 'imagery', 'If emotions were colors in a song, which would paint your current mood?', TRUE),
+  (7, 'genre', 'Which musical genre best describes your current outlook?', TRUE);

--- a/supabase/policies/initial_dialogue_options.sql
+++ b/supabase/policies/initial_dialogue_options.sql
@@ -16,6 +16,6 @@ CREATE POLICY "Authenticated users read options"
       SELECT 1
       FROM initial_dialogue_templates t
       WHERE t.id = template_id
-        AND t.is_active
+        AND t.active
     )
   );

--- a/supabase/policies/initial_dialogue_templates.sql
+++ b/supabase/policies/initial_dialogue_templates.sql
@@ -10,4 +10,4 @@ CREATE POLICY "Admins can modify dialogue templates"
 CREATE POLICY "Authenticated users read active templates"
   ON initial_dialogue_templates
   FOR SELECT
-  USING (auth.uid() IS NOT NULL AND is_active);
+  USING (auth.uid() IS NOT NULL AND active);


### PR DESCRIPTION
## Summary
- recreate `initial_dialogue_templates` with prompt-focused fields and seed sample prompts
- update policies to use new `active` flag
- document schema change in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6891dc36c2cc832eaacc62d06604bf3b