### PR TITLE
feat: capture detailed initial profile

### DIFF
--- a/src/components/InitialDialogueForm.tsx
+++ b/src/components/InitialDialogueForm.tsx
@@ -6,26 +6,23 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/lib/supabaseClient';
 import { useAppContext } from '@/contexts/AppContext';
-
-interface QA {
-  q: string;
-  a: string;
-}
+import type { UserInitialProfile } from '@/types/userInitialProfile';
 
 interface Props {
-  initialAnswers: QA[];
+  initialProfile: UserInitialProfile;
 }
 
-const InitialDialogueForm: React.FC<Props> = ({ initialAnswers }) => {
+const InitialDialogueForm: React.FC<Props> = ({ initialProfile }) => {
   const { user, refreshInitialDialogueResponses } = useAppContext();
-  const [answers, setAnswers] = useState<QA[]>(initialAnswers);
+  const [profile, setProfile] = useState<UserInitialProfile>(initialProfile);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   if (!user) return null;
 
-  const handleChange = (index: number, value: string) => {
-    setAnswers(prev => prev.map((qa, i) => (i === index ? { ...qa, a: value } : qa)));
+  const handleChange = (field: keyof UserInitialProfile, value: string) => {
+    const values = value.split(',').map(v => v.trim()).filter(Boolean);
+    setProfile(prev => ({ ...prev, [field]: values }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -35,7 +32,7 @@ const InitialDialogueForm: React.FC<Props> = ({ initialAnswers }) => {
       await supabase.from('user_initial_dialogue_responses').upsert(
         {
           user_id: user.id,
-          responses: answers,
+          responses: profile,
         },
         { onConflict: 'user_id' }
       );
@@ -48,28 +45,84 @@ const InitialDialogueForm: React.FC<Props> = ({ initialAnswers }) => {
     }
   };
 
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(profile, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'initial_profile.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-indigo-50 p-4">
       <Card className="w-full max-w-2xl">
         <CardHeader>
           <CardTitle>Getting Started</CardTitle>
-          <CardDescription>Review your answers before generating songs.</CardDescription>
+          <CardDescription>Review your profile before generating songs.</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
-            {answers.map((qa, idx) => (
-              <div key={idx} className="space-y-2">
-                <Label htmlFor={`q-${idx}`}>{qa.q}</Label>
-                <Input
-                  id={`q-${idx}`}
-                  value={qa.a}
-                  onChange={(e) => handleChange(idx, e.target.value)}
-                  required
-                />
-              </div>
-            ))}
+            <div className="space-y-2">
+              <Label htmlFor="emotional_keywords">Emotional Keywords</Label>
+              <Input
+                id="emotional_keywords"
+                value={profile.emotional_keywords.join(', ')}
+                onChange={(e) => handleChange('emotional_keywords', e.target.value)}
+                placeholder="e.g., hopeful, calm"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="emotional_valence">Emotional Valence</Label>
+              <Input
+                id="emotional_valence"
+                value={profile.emotional_valence.join(', ')}
+                onChange={(e) => handleChange('emotional_valence', e.target.value)}
+                placeholder="e.g., positive, negative"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="core_images_or_concepts">Core Images or Concepts</Label>
+              <Input
+                id="core_images_or_concepts"
+                value={profile.core_images_or_concepts.join(', ')}
+                onChange={(e) => handleChange('core_images_or_concepts', e.target.value)}
+                placeholder="e.g., mountains, ocean"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="preferred_music_styles">Preferred Music Styles</Label>
+              <Input
+                id="preferred_music_styles"
+                value={profile.preferred_music_styles.join(', ')}
+                onChange={(e) => handleChange('preferred_music_styles', e.target.value)}
+                placeholder="e.g., jazz, pop"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="favorite_artists">Favorite Artists</Label>
+              <Input
+                id="favorite_artists"
+                value={profile.favorite_artists.join(', ')}
+                onChange={(e) => handleChange('favorite_artists', e.target.value)}
+                placeholder="e.g., Artist A, Artist B"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="favorite_songs">Favorite Songs</Label>
+              <Input
+                id="favorite_songs"
+                value={profile.favorite_songs.join(', ')}
+                onChange={(e) => handleChange('favorite_songs', e.target.value)}
+                placeholder="e.g., Song A, Song B"
+              />
+            </div>
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? 'Saving...' : 'Save'}
+            </Button>
+            <Button type="button" variant="outline" className="w-full" onClick={handleExport}>
+              Export as JSON
             </Button>
           </form>
         </CardContent>

--- a/src/pages/InitialDialoguePage.tsx
+++ b/src/pages/InitialDialoguePage.tsx
@@ -1,101 +1,43 @@
 import React, { useEffect, useState } from 'react';
 import { AppProvider, useAppContext } from '@/contexts/AppContext';
 import { supabase } from '@/lib/supabaseClient';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import InitialDialogueForm from '@/components/InitialDialogueForm';
+import type { UserInitialProfile } from '@/types/userInitialProfile';
 
-interface QA {
-  q: string;
-  a: string;
-}
+const defaultProfile: UserInitialProfile = {
+  emotional_keywords: [],
+  emotional_valence: [],
+  core_images_or_concepts: [],
+  preferred_music_styles: [],
+  favorite_artists: [],
+  favorite_songs: [],
+};
 
 const InitialDialogueInner: React.FC = () => {
   const { user } = useAppContext();
-  const [context, setContext] = useState<QA[]>([]);
-  const [question, setQuestion] = useState('');
-  const [answer, setAnswer] = useState('');
+  const [profile, setProfile] = useState<UserInitialProfile>(defaultProfile);
   const [loading, setLoading] = useState(true);
-  const [showForm, setShowForm] = useState(false);
-  const [totalQuestions, setTotalQuestions] = useState<number | null>(null);
 
   useEffect(() => {
-    const init = async () => {
+    const load = async () => {
       if (!user) return;
       setLoading(true);
-
-      const { data: existing } = await supabase
+      const { data } = await supabase
         .from('user_initial_dialogue_responses')
         .select('responses')
         .eq('user_id', user.id)
         .single();
-
-      if (existing?.responses) {
-        setContext(existing.responses as QA[]);
-        setShowForm(true);
-        setLoading(false);
-        return;
+      if (data?.responses) {
+        setProfile(data.responses as UserInitialProfile);
       }
-
-      const { count } = await supabase
-        .from('initial_dialogue_templates')
-        .select('id', { count: 'exact', head: true })
-        .eq('active', true);
-      setTotalQuestions(count ?? null);
-
-      await fetchQuestion([]);
+      setLoading(false);
     };
-    init();
+    load();
   }, [user]);
 
-  const fetchQuestion = async (ctx: QA[]) => {
-    setLoading(true);
-    try {
-      const { data, error } = await supabase.functions.invoke('ai_router', {
-        body: { mode: 'interview', context: ctx },
-      });
-      if (error) throw error;
-      if ((data as { done?: boolean }).done) {
-        setShowForm(true);
-        setContext(ctx);
-      } else {
-        const nextQuestion =
-          (data as { question?: string }).question ||
-          (data as { prompt?: string }).prompt ||
-          '';
-        setQuestion(nextQuestion);
-      }
-    } catch (err) {
-      console.error('Failed to load question', err);
-      setQuestion('');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const newCtx = [...context, { q: question, a: answer }];
-    setContext(newCtx);
-    setAnswer('');
-    await fetchQuestion(newCtx);
-  };
-
   if (loading) return <div className="p-4">Loading...</div>;
-  if (showForm) return <InitialDialogueForm initialAnswers={context} />;
 
-  return (
-    <form onSubmit={handleSubmit} className="p-4 space-y-4 max-w-xl mx-auto">
-      {totalQuestions !== null && (
-        <div className="text-sm text-muted-foreground">
-          Question {context.length + 1} of {totalQuestions}
-        </div>
-      )}
-      <div className="text-lg font-medium">{question}</div>
-      <Input value={answer} onChange={(e) => setAnswer(e.target.value)} required />
-      <Button type="submit">Next</Button>
-    </form>
-  );
+  return <InitialDialogueForm initialProfile={profile} />;
 };
 
 export default function InitialDialoguePage() {
@@ -105,4 +47,3 @@ export default function InitialDialoguePage() {
     </AppProvider>
   );
 }
-

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -21,7 +21,7 @@ const LoginInner: React.FC = () => {
           .select('id')
           .eq('user_id', session.user.id)
           .limit(1);
-        navigate(data && data.length > 0 ? '/dashboard' : '/dialogue', { replace: true });
+        navigate(data && data.length > 0 ? '/dashboard' : '/initial-dialogue', { replace: true });
       }
     };
     checkSession();
@@ -45,7 +45,7 @@ const LoginInner: React.FC = () => {
       .eq('user_id', data.user.id)
       .limit(1);
 
-    navigate(dialogueData && dialogueData.length > 0 ? '/dashboard' : '/dialogue');
+    navigate(dialogueData && dialogueData.length > 0 ? '/dashboard' : '/initial-dialogue');
     setLoading(false);
   };
 

--- a/src/types/userInitialProfile.ts
+++ b/src/types/userInitialProfile.ts
@@ -1,0 +1,8 @@
+export interface UserInitialProfile {
+  emotional_keywords: string[];
+  emotional_valence: string[];
+  core_images_or_concepts: string[];
+  preferred_music_styles: string[];
+  favorite_artists: string[];
+  favorite_songs: string[];
+}


### PR DESCRIPTION
## Summary
- replace goal question with structured initial profile form
- save profile as JSON and allow exporting it
- load existing profile data on login

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891ea2c691c832ebd65ebd02de27ab9