### PR TITLE
feat: redirect login to dialogue

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -17,12 +17,7 @@ const LoginInner: React.FC = () => {
     const checkSession = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       if (session?.user) {
-        const { data } = await supabase
-          .from('user_initial_dialogue_responses')
-          .select('id')
-          .eq('user_id', session.user.id)
-          .limit(1);
-        navigate(data && data.length > 0 ? '/dashboard' : '/initial-dialogue', { replace: true });
+        navigate('/dialogue', { replace: true });
       }
     };
     checkSession();
@@ -52,13 +47,7 @@ const LoginInner: React.FC = () => {
         return;
       }
 
-      const { data: dialogueData } = await supabase
-        .from('user_initial_dialogue_responses')
-        .select('id')
-        .eq('user_id', data.user.id)
-        .limit(1);
-
-      navigate(dialogueData && dialogueData.length > 0 ? '/dashboard' : '/initial-dialogue');
+      navigate('/dialogue');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- simplify login flow by always routing authenticated users to `/dialogue`
- remove unused `user_initial_dialogue_responses` queries from login page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891f721ad20832e88330f8263eca278